### PR TITLE
Add Emscripten sample builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ else ifeq ($(platform), linux)
 	LIBS+=-lX11 -lXi -lXcursor -lGL -ldl -lm
 else ifeq ($(platform), macos)
 	LIBS+=-lCocoa -lQuartzCore -lMetal -lMetalKit
+else ifeq ($(platform), web)
+	LIBS+=-sUSE_WEBGL2=1
+	CC=emcc
+	OUTEXT=.html
+	CFLAGS+=--shell-file=samples/sample-shell.html
 endif
 
 # build type
@@ -41,7 +46,11 @@ ifndef build
 	build=debug
 endif
 ifeq ($(build), debug)
-	CFLAGS+=-Og -g
+	ifeq ($(platform), web)
+		CFLAGS+=-O0
+	else
+		CFLAGS+=-Og -g
+	endif
 else ifeq ($(build), release)
 	CFLAGS+=-O3 -g -ffast-math -fno-plt -flto
 	DEFS+=-DNDEBUG
@@ -53,6 +62,8 @@ ifndef backend
 		backend=d3d11
 	else ifeq ($(platform), macos)
 		backend=metal
+	else ifeq ($(platform), web)
+		backend=gles3
 	else
 		backend=glcore33
 	endif

--- a/samples/sample-shell.html
+++ b/samples/sample-shell.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>
+    <title>sokol_gp</title>
+    <style>
+        body { margin: 0; background-color: black }
+        .game {
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            margin: 0px;
+            border: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            display: block;
+            image-rendering: optimizeSpeed;
+            image-rendering: -moz-crisp-edges;
+            image-rendering: -o-crisp-edges;
+            image-rendering: -webkit-optimize-contrast;
+            image-rendering: optimize-contrast;
+            image-rendering: crisp-edges;
+            image-rendering: pixelated;
+            -ms-interpolation-mode: nearest-neighbor;
+        }
+    </style>
+  </head>
+  <body>
+    <canvas class="game" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    <script type='text/javascript'>
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+            return function(text) {
+                text = Array.prototype.slice.call(arguments).join(' ');
+                console.log(text);
+            };
+        })(),
+        printErr: function(text) {
+            text = Array.prototype.slice.call(arguments).join(' ');
+            console.error(text);
+        },
+        canvas: (function() {
+            var canvas = document.getElementById('canvas');
+            //canvas.addEventListener("webglcontextlost", function(e) { alert('FIXME: WebGL context lost, please reload the page'); e.preventDefault(); }, false);
+            return canvas;
+        })(),
+        setStatus: function(text) {
+            console.log("status: " + text);
+        },
+        monitorRunDependencies: function(left) {
+            console.log("monitor run deps: " + left);
+        }
+      };
+      window.onerror = function() {
+        console.log("onerror: " + event.message);
+      };
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>


### PR DESCRIPTION
This adds definitions for building for the web. You will need [emcc](https://emscripten.org/) installed. Also need to run a web server that supports `.wasm` file requests.

```
make platform=web
```
![Screenshot at 2022-04-16 17-54-48](https://user-images.githubusercontent.com/25086/163692523-d925b14c-e5d4-4e16-bd02-263d56bf8e85.png)

## Caveat

sample-effect's doesn't work since `load_image()` loads an image using `stbi_load()`. File system loading has to be switched to use `sokol_fetch.h` instead of through straight up file system.